### PR TITLE
2.0.0: Laravel 13 support, drop Laravel 10/11 + PHP 8.2. 

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,18 +17,15 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3, 8.2]
-        laravel: [12.*, 11.*, 10.*]
+        php: [8.5, 8.4, 8.3]
+        laravel: [13.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-            carbon: ^2.63
-          - laravel: 11.*
-            testbench: ^9.0
-            carbon: ^3.8
           - laravel: 12.*
             testbench: ^10.0
+            carbon: ^3.8
+          - laravel: 13.*
+            testbench: ^11.0
             carbon: ^3.8
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `referable` will be documented in this file.
 
+## 2.0.0 - 2026-04-22
+
+- Laravel 13 support
+- Dropped support for Laravel 10 and Laravel 11
+- Dropped support for PHP 8.2 (minimum PHP version is now 8.3)
+
 ## 1.3 - 2025-03-03
 
 Laravel 12 support

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "perfect-drive/referable",
     "description": "Automatically create routes for Models and Enums to make them referable in your Laravel backed SPA frontend",
-    "version": "1.3.0",
+    "version": "2.0.0",
     "keywords": [
         "Perfect Drive",
         "laravel",
@@ -17,18 +17,18 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^10.0||^11.0||^12.0"
+        "illuminate/contracts": "^12.0||^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
-        "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "larastan/larastan": "^2.9||^3.0",
-        "orchestra/testbench": "^10.0.0||^9.0.0||^8.22.0",
-        "pestphp/pest": "^2.36||^3.0",
-        "pestphp/pest-plugin-arch": "^2.7.0||^3.0",
-        "pestphp/pest-plugin-laravel": "^2.4.0||^3.0",
+        "nunomaduro/collision": "^8.1.1",
+        "larastan/larastan": "^3.0",
+        "orchestra/testbench": "^11.0.0||^10.0.0",
+        "pestphp/pest": "^3.0||^4.0",
+        "pestphp/pest-plugin-arch": "^3.0||^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0||^4.0",
         "phpstan/extension-installer": "^1.3||^2.0",
         "phpstan/phpstan-deprecation-rules": "^1.1||^2.0",
         "phpstan/phpstan-phpunit": "^1.3||^2.0"


### PR DESCRIPTION
2.0.0: Laravel 13 support, drop Laravel 10/11 + PHP 8.2. 